### PR TITLE
fixed build issue#9 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-optitrack2_driver/NatNetSDK/*
-!optitrack2_driver/NatNetSDK/.gitkeep
+mocap_optitrack_driver/NatNetSDK/*
+!mocap_optitrack_driver/NatNetSDK/.gitkeep

--- a/mocap_optitrack_driver/CMakeLists.txt
+++ b/mocap_optitrack_driver/CMakeLists.txt
@@ -41,14 +41,9 @@ include_directories(
   ${NATNET_INCLUDE_DIR}
 )
 
-add_custom_command(OUTPUT ${LIBNATNET_SDK_LIBRARY} ${NATNET_INCLUDE_DIR}
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/install_sdk.py
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-)
-
-add_custom_target(
-  GetNatNetSDK ALL
-  DEPENDS ${LIBNATNET_SDK_LIBRARY}
+execute_process(
+	COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/install_sdk.py
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_library(${PROJECT_NAME} 

--- a/mocap_optitrack_driver/NatNetSDK/.gitignore
+++ b/mocap_optitrack_driver/NatNetSDK/.gitignore
@@ -1,3 +1,0 @@
-include
-lib
-samples

--- a/mocap_optitrack_driver/install_sdk.py
+++ b/mocap_optitrack_driver/install_sdk.py
@@ -17,26 +17,32 @@ import requests
 import tarfile
 import os
 
-print('Downloading started')
+dir = os.listdir('NatNetSDK/')
 
-""" Tiny URL for
-  https://s3.amazonaws.com/naturalpoint/software/
-  NatNetSDKLinux/ubuntu/NatNet_SDK_4.0_ubuntu.tar
-"""
-url = 'https://tinyurl.com/4j3j8434' 
-req = requests.get(url)
-print(url)
-filename = 'NatNetSDK.tar'
+if 'lib' in dir and 'include' in dir:
+    pass
 
-with open(filename, 'wb') as output_file:
-    output_file.write(req.content)
-print('Downloading completed')
+else:
+    #print('Downloading started')
 
-print('Extracting started')
-tar = tarfile.open(filename)
-tar.extractall(path='NatNetSDK/')
-tar.close()
-print('Extracting completed')
+    """ Tiny URL for
+      https://s3.amazonaws.com/naturalpoint/software/
+      NatNetSDKLinux/ubuntu/NatNet_SDK_4.0_ubuntu.tar
+    """
+    url = 'https://tinyurl.com/4j3j8434' 
+    req = requests.get(url)
+    #print(url)
+    filename = 'NatNetSDK.tar'
 
-os.remove(filename)
-print('Removed extra files')
+    with open(filename, 'wb') as output_file:
+        output_file.write(req.content)
+    #print('Downloading completed')
+
+    #print('Extracting started')
+    tar = tarfile.open(filename)
+    tar.extractall(path='NatNetSDK/')
+    tar.close()
+    #print('Extracting completed')
+
+    os.remove(filename)
+    #print('Removed extra files')


### PR DESCRIPTION
Hello devs,

This PR refers to the fix of issue #9  

[execute_process](https://cmake.org/cmake/help/v3.0/command/execute_process.html) executes the process prior to the build process. That avoids the missing include issues for the natnet sdk.