### PR TITLE
Changed paths for libNatNet

### DIFF
--- a/mocap4r2_optitrack_driver/CMakeLists.txt
+++ b/mocap4r2_optitrack_driver/CMakeLists.txt
@@ -11,9 +11,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(LIBNATNET_SDK_LIBRARY ${CMAKE_CURRENT_SOURCE_DIR}/NatNetSDK/lib/libNatNet.so)
+set(LIBNATNET_SDK_LIBRARY ${CMAKE_CURRENT_LIST_DIR}/NatNetSDK/lib/libNatNet.so)
 set(NATNET_INCLUDE_DIR
-  ${CMAKE_CURRENT_SOURCE_DIR}/NatNetSDK/include
+  ${CMAKE_CURRENT_LIST_DIR}/NatNetSDK/include
 )
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Good evening,

Me and @BoroBonez are working with optitrack at our university lab and we found this package.

We tried to compile and launch you package, however we encountered the following error:
```
[INFO] [mocap4r2_optitrack_driver_main-1]: process started with pid [24650]
[mocap4r2_optitrack_driver_main-1] path/to/ros2_ws/install/mocap4r2_optitrack_driver/lib/mocap4r2_optitrack_driver/mocap4r2_optitrack_driver_main: error while loading shared libraries: libNatNet.so: cannot open shared object file: No such file or directory
```

We think that colcon might internally change the ``CMAKE_CURRENT_SOURCE_DIR``, thus the linking fails (since you don't export the shared library in the ``share/mocap4r2_optitrack_driver/lib`` path). I don't know if this is intentional.

As a workaround we changed ``CMAKE_CURRENT_SOURCE_DIR`` to ````CMAKE_CURRENT_LIST_DIR`` for the NatNet SDK, and for now it seems to load correctly the shared library at runtime.

One other solution could be to install ``libNatNet.so`` directly in the share folder of the package.

Hoping to help the community, we are happy to hear your feedback!