### PR TITLE
Copy the NatNetSDK shared object into the install folder

### DIFF
--- a/mocap4r2_optitrack_driver/CMakeLists.txt
+++ b/mocap4r2_optitrack_driver/CMakeLists.txt
@@ -75,6 +75,9 @@ install(TARGETS
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
+install(FILES ${CMAKE_SOURCE_DIR}/NatNetSDK/lib/libNatNet.so
+        DESTINATION lib)
+
 install(TARGETS
   ${PROJECT_NAME}
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
I might be missing something obvious here, but it seems like the NatNetSDK.so doesn't get installed, and is therefore not present on LD_LIBRARY_PATH by default:
```
root@kalman:~/ros2_ws# ros2 launch mocap_optitrack_driver optitrack2.launch.py        
[INFO] [launch]: All log files can be found below /root/.ros/log/2025-07-21-15-05-47-910888-kalman-98604
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [mocap_optitrack_driver_main-1]: process started with pid [98620]
[ERROR] [mocap_optitrack_driver_main-1]: process has died [pid 98620, exit code 127, cmd '/root/ros2_ws/install/mocap_optitrack_driver/lib/mocap_optitrack_driver/mocap_op
titrack_driver_main --ros-args -r __node:=mocap_optitrack_driver_node -r __ns:=/ --params-file /root/ros2_ws/install/mocap_optitrack_driver/share/mocap_optitrack_driver/c
onfig/mocap_optitrack_driver_params.yaml'].
[mocap_optitrack_driver_main-1] /root/ros2_ws/install/mocap_optitrack_driver/lib/mocap_optitrack_driver/mocap_optitrack_driver_main: error while loading shared libraries:
 libNatNet.so: cannot open shared object file: No such file or directory
```
It think it would be useful to add this.