### PR TITLE
Add parameter for reference frame

### DIFF
--- a/mocap4r2_optitrack_driver/include/mocap4r2_optitrack_driver/mocap4r2_optitrack_driver.hpp
+++ b/mocap4r2_optitrack_driver/include/mocap4r2_optitrack_driver/mocap4r2_optitrack_driver.hpp
@@ -111,6 +111,8 @@ protected:
   uint16_t server_data_port_;
 
   uint32_t frame_number_{0};
+
+  std::string reference_frame_;
 };
 
 void NATNET_CALLCONV process_frame_callback(sFrameOfMocapData * data, void * pUserData);

--- a/mocap4r2_optitrack_driver/src/mocap4r2_optitrack_driver/mocap4r2_optitrack_driver.cpp
+++ b/mocap4r2_optitrack_driver/src/mocap4r2_optitrack_driver/mocap4r2_optitrack_driver.cpp
@@ -43,6 +43,7 @@ OptitrackDriverNode::OptitrackDriverNode()
   declare_parameter<std::string>("multicast_address", "000.000.000.000");
   declare_parameter<uint16_t>("server_command_port", 0);
   declare_parameter<uint16_t>("server_data_port", 0);
+  declare_parameter<std::string>("reference_frame", "map");
 
   client = new NatNetClient();
   client->SetFrameReceivedCallback(process_frame_callback, this);
@@ -136,7 +137,7 @@ OptitrackDriverNode::process_frame(sFrameOfMocapData * data)
   if (mocap4r2_markers_pub_->get_subscription_count() > 0) {
     mocap4r2_msgs::msg::Markers msg;
     msg.header.stamp = now() - frame_delay;
-    msg.header.frame_id = "map";
+    msg.header.frame_id = reference_frame_;
     msg.frame_number = frame_number_;
 
     for (int i = 0; i < data->nLabeledMarkers; i++) {
@@ -164,7 +165,7 @@ OptitrackDriverNode::process_frame(sFrameOfMocapData * data)
   if (mocap4r2_rigid_body_pub_->get_subscription_count() > 0) {
     mocap4r2_msgs::msg::RigidBodies msg_rb;
     msg_rb.header.stamp = now() - frame_delay;
-    msg_rb.header.frame_id = "map";
+    msg_rb.header.frame_id = reference_frame_;
     msg_rb.frame_number = frame_number_;
 
     for (int i = 0; i < data->nRigidBodies; i++) {
@@ -351,6 +352,7 @@ OptitrackDriverNode::initParameters()
   get_parameter<std::string>("multicast_address", multicast_address_);
   get_parameter<uint16_t>("server_command_port", server_command_port_);
   get_parameter<uint16_t>("server_data_port", server_data_port_);
+  get_parameter<std::string>("reference_frame", reference_frame_);
 }
 
 }  // namespace mocap4r2_optitrack_driver


### PR DESCRIPTION
The driver always publishes rigid bodies and marker topics with frame_id "map". This patch adds the option to change this using a parameter reference_frame.